### PR TITLE
Setuptools and not leaving certs behind

### DIFF
--- a/demos/invoice_demo.py
+++ b/demos/invoice_demo.py
@@ -43,7 +43,7 @@ class InvoiceDemo():
         print("ZOI: " + zoi)
 
         # Let's obtain data for Code128/QR/PDF417 that should be placed at the bottom of the Invoice
-        print_data = api.prepare_qr(tax_number=10039856,
+        print_data = api.prepare_printable(tax_number=10039856,
                                     zoi=zoi,
                                     issued_date=date_issued)
 

--- a/furs_fiscal/api.py
+++ b/furs_fiscal/api.py
@@ -204,31 +204,9 @@ class FURSInvoiceAPI(FURSBaseAPI):
 
         return hashlib.md5(self._sign(content=content)).hexdigest()
 
-    def prepare_qr(self, tax_number, zoi, issued_date):
+    def prepare_printable(self, tax_number, zoi, issued_date):
         """
-        Get Data Record for QR Code that should be placed at the bottom of the Invoice.
-
-        :param tax_number:
-        :param zoi:
-        :param issued_date:
-        :return: (string) Data Record
-        """
-        return FURSInvoiceAPI._prepare_zoi_for_print(tax_number=tax_number, zoi=zoi, issued_date=issued_date)
-
-    def prepare_code128(self, tax_number, zoi, issued_date):
-        """
-        Get Data Record for Code 128 that should be placed at the bottom of the Invoice.
-
-        :param tax_number:
-        :param zoi:
-        :param issued_date:
-        :return: (string) Data Record
-        """
-        return FURSInvoiceAPI._prepare_zoi_for_print(tax_number=tax_number, zoi=zoi, issued_date=issued_date)
-
-    def prepare_pdf417(self, tax_number, zoi, issued_date):
-        """
-        Get Data Record for PDF 417 that should be placed at the bottom of the Invoice.
+        Get Data Record for QR Code/Code 128/PDF417 that should be placed at the bottom of the Invoice.
 
         :param tax_number:
         :param zoi:

--- a/furs_fiscal/base_api.py
+++ b/furs_fiscal/base_api.py
@@ -7,7 +7,7 @@ from connector import Connector
 from exceptions import ConnectionException, ConnectionTimedOutException, FURSException
 
 
-class FURSBaseAPI():
+class FURSBaseAPI(object):
     def __init__(self, p12_path, p12_password, production=True, request_timeout=2.0):
         self.connector = Connector(p12_path=p12_path,
                                    p12_password=p12_password,

--- a/furs_fiscal/connector.py
+++ b/furs_fiscal/connector.py
@@ -17,7 +17,7 @@ FURS_TEST_CERT = os.path.join(os.path.dirname(__file__), 'certs/test_certificate
 FURS_PRODUCTION_CERT = os.path.join(os.path.dirname(__file__), 'certs/test_certificate.pem')
 
 
-class Connector():
+class Connector(object):
     """
     Connector performs all the communication with the FURS server.
 
@@ -63,13 +63,13 @@ class Connector():
 
         :return: None
         """
-        self.cert_temp = tempfile.NamedTemporaryFile(delete=False)
+        self.cert_temp = tempfile.NamedTemporaryFile()
         self.cert_temp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, self.p12.get_certificate()))
-        self.cert_temp.close()
+        self.cert_temp.flush()
 
-        self.pkey_temp = tempfile.NamedTemporaryFile(delete=False)
+        self.pkey_temp = tempfile.NamedTemporaryFile()
         self.pkey_temp.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, self.p12.get_privatekey()))
-        self.pkey_temp.close()
+        self.pkey_temp.flush()
 
     def _get_jws_header(self):
         """
@@ -150,6 +150,3 @@ class Connector():
         :return: (dict) request header
         """
         return {'Content-Type': 'application/json; charset=UTF-8'}
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+from setuptools import setup
+
 setup(
   name = 'furs_fiscal',
   packages = ['furs_fiscal'],


### PR DESCRIPTION
Small fixes:
- use setuptools (recommended)
- don't leave cert files behind
- only leave one method for outputting printable ID string
